### PR TITLE
Use Components instead of Flags inside Codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,35 @@
+# Based on https://docs.codecov.com/docs/common-recipe-list#set-non-blocking-status-checks
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+# Based on https://docs.codecov.com/docs/flags#recommended-automatic-flag-management
+flag_management:
+  default_rules:
+    statuses:
+      - type: project
+        informational: true
+      - type: patch
+        informational: true
+# Based on https://docs.codecov.com/docs/components
+# Based on https://github.com/codecov/example-components
+# Based on https://about.codecov.io/blog/codecov-components-breaking-down-coverage-by-filters/
+# Based on https://about.codecov.io/blog/granular-test-coverage-analysis-using-components-in-codecov/
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        informational: true
+      - type: patch
+        informational: true
+  individual_components:
+    - component_id: "id_libimgdoc2"
+      name: libimgdoc2
+      paths:
+        - "libimgdoc2/"
+comment:
+  layout: "header, diff, flags, components"  # show component info in the PR comment

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -5,8 +5,6 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -60,9 +60,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
           directory: ${{github.workspace}}/coveragebuild
           files: code_coverage.xml
-          flags: unittests
-          name: code-coverage
           verbose: true

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -5,6 +5,8 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

Add codecov.yml to make use of Codecov components
  - Based on https://docs.codecov.com/docs/components
  - Based on https://github.com/codecov/example-components
  - Based on https://about.codecov.io/blog/codecov-components-breaking-down-coverage-by-filters/
  - Based on https://about.codecov.io/blog/granular-test-coverage-analysis-using-components-in-codecov/ 

Use components to cluster tests and their coverage based on paths in our monorepo.

Remove GH Token from passing into action since this is not necessary when following the HowTo in:
![image](https://user-images.githubusercontent.com/9250590/229703000-8e8612e7-9edb-491b-a08c-f95e34c3e018.png)
![image](https://user-images.githubusercontent.com/9250590/229704404-7edab956-7a57-4413-b9f6-af75d63a6ee4.png)

@ptahmose This is probably what you should do for your fork as well in order for the action to run without passing in the GH Token. For https://github.com/ZEISS/imgdoc2 it should theoretically work out of the box - if not I will do the necessary adjustments there.

## Background/Motivation 
Flags are rather static and need to be matched to coverage report uploads at upload time
Components on the other hand can be changed at any time through codecov.yml while preserving basically the same functionality as flags
Recommended for new projects to start-off directly with components -> https://docs.codecov.com/docs/components#should-i-use-flags-or-components
As opposed to https://app.codecov.io/gh/ZEISS/libczi/flags, it is not intended to cluster coverage according to OS anymore since it does not really make sense and only clutters the dashboard and everything. It is enough to run tests on different OS, but measuring coverage across different OS does not really add value. As soon as flags can be easily removed (which is despite https://github.com/ZEISS/libczi/issues/33 still the case as of now), we will do so for libCZI.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

https://github.com/FelixS90/imgdoc2/actions/runs/4604202084

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
